### PR TITLE
Changed wrapper url.

### DIFF
--- a/content/android/gettingstarted.md
+++ b/content/android/gettingstarted.md
@@ -69,7 +69,7 @@ sudo apt-get install git
 The repository can then be cloned from github:
 
 ```sh
-git clone https://github.com/vidhance/android-camera-wrapper
+git clone https://github.com/vidhance/android-camera-wrapper-legacy
 ```
 
 ## Setting up help functions


### PR DESCRIPTION
The public wrapper code is now located in a different repo.
@erikhagglund peer review